### PR TITLE
REFACTOR: replaced link to old .csv to new one

### DIFF
--- a/iris.script
+++ b/iris.script
@@ -5,7 +5,7 @@
 
     zn "USER"
     ; zpm "install csvgen"
-    ; d ##class(community.csvgen).GenerateFromURL("https://raw.githubusercontent.com/google/dspl/master/samples/google/canonical/countries.csv",",","dc.data.Country")
+    ; d ##class(community.csvgen).GenerateFromURL("https://raw.githubusercontent.com/intersystems-community/iris-dataset-countries/refs/heads/master/data/countries.csv",",","dc.data.Country")
 
     zpm "load /opt/irisbuild/ -v":1:1
     halt


### PR DESCRIPTION
The previous comes from https://github.com/google/dspl/tree/master/samples/google/canonical

The new one is from the repo itself